### PR TITLE
Increase the operations-per-run limit to 500

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,4 +18,6 @@ runs:
         days-before-close: 7
         # Do not touch any issues
         days-before-issue-stale: -1
-        days-before-issue-close: -1 
+        days-before-issue-close: -1
+        # Operations limit is used for issues and PRs, even if issues are not touched
+        operations-per-run: 500


### PR DESCRIPTION
While running the action in the osbuild repository, we hit the default limit for operations-per-run (30) and as result, not all old PRs without updated have been marked as stale. The reason is that the action consumes the operations budget even for issues, even if not checked. So to ensure that all PRs will be processed, the limit must be higher than the sum of number of issues and PRs in the repository.

All of our repos use the action-specific GITHUB_TOKEN for this action.

GitHub documentation states [1]:
When using GITHUB_TOKEN, the rate limit is 1,000 requests per hour per repository.

The osbuild-composer repo currently has the highest number of open issues and PRs (219). Since the limit is 1000 per repo per hour and since the action is run at 4 AM UTC, I think that it is safe to increase the operations-per-run limit to 500. The consumed budget should renew when most of the people start their day and in addition, we don't use action-specific token much (or at all) in most of our repos. This limit will ensure that all PRs will be checked as part of the action run.

[1] https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-apps